### PR TITLE
Create types directory and change Table implementation

### DIFF
--- a/packages/rockets-next-web/src/app/(main)/profile/ChangePasswordForm.tsx
+++ b/packages/rockets-next-web/src/app/(main)/profile/ChangePasswordForm.tsx
@@ -1,4 +1,5 @@
 import { FC, useState } from "react";
+import type { IChangeEvent } from "@rjsf/core";
 import { SchemaForm } from "@concepta/react-material-ui";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
@@ -28,7 +29,11 @@ const ChangePasswordForm: FC<ChangePasswordFormProps> = ({
     confirmNewPassword: "",
   });
 
-  const handleFormSubmit = () => {
+  const handleFormSubmit = async (
+    values: IChangeEvent<PasswordChangeFormData>
+  ) => {
+    console.log(values);
+
     closePasswordChangeModal();
     openConfirmationModal();
   };

--- a/packages/rockets-next-web/src/app/(main)/profile/formConfig.ts
+++ b/packages/rockets-next-web/src/app/(main)/profile/formConfig.ts
@@ -13,6 +13,7 @@ export const profileFormSchema: RJSFSchema = {
   type: "object",
   required: ["firstName", "lastName"],
   properties: {
+    email: { type: "string", title: "Email", minLength: 3, readOnly: true },
     firstName: { type: "string", title: "First name", minLength: 3 },
     lastName: { type: "string", title: "Last name", minLength: 3 },
   },

--- a/packages/rockets-next-web/src/app/(main)/profile/formConfig.ts
+++ b/packages/rockets-next-web/src/app/(main)/profile/formConfig.ts
@@ -43,6 +43,21 @@ export const advancedProperties: Record<string, AdvancedProperty> = {
 
 export const validationRules: ValidationRule<PasswordChangeFormData>[] = [
   {
+    field: "oldPassword",
+    test: (value) => !value,
+    message: "Required field",
+  },
+  {
+    field: "newPassword",
+    test: (value) => !value,
+    message: "Required field",
+  },
+  {
+    field: "confirmNewPassword",
+    test: (value) => !value,
+    message: "Required field",
+  },
+  {
     field: "confirmNewPassword",
     test: (value, formData) => value !== formData.newPassword,
     message: "Your passwords don't match. Please try again",

--- a/packages/rockets-next-web/src/app/(main)/profile/page.tsx
+++ b/packages/rockets-next-web/src/app/(main)/profile/page.tsx
@@ -9,7 +9,8 @@ import useTheme from "@mui/material/styles/useTheme";
 
 import ChangePasswordForm from "./ChangePasswordForm";
 import ConfirmationModal from "./ConfirmationModal";
-import { UserData } from "./types";
+
+import type { User } from "@/types/User";
 
 const ProfileScreen: FC = () => {
   const theme = useTheme();
@@ -61,7 +62,7 @@ const ProfileScreen: FC = () => {
       </Box>
 
       <Box mb={3} sx={{ maxWidth: "406px" }}>
-        <TextField label="Email" value={(user as UserData)?.email} disabled />
+        <TextField label="Email" value={(user as User)?.email} disabled />
       </Box>
 
       <Button

--- a/packages/rockets-next-web/src/app/(main)/profile/page.tsx
+++ b/packages/rockets-next-web/src/app/(main)/profile/page.tsx
@@ -5,7 +5,9 @@ import { Dialog, TextField, Text } from "@concepta/react-material-ui";
 import { useAuth } from "@concepta/react-auth-provider";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
+import CircularProgress from "@mui/material/CircularProgress";
 import useTheme from "@mui/material/styles/useTheme";
+import { toast } from "react-toastify";
 
 import ChangePasswordForm from "./ChangePasswordForm";
 import ConfirmationModal from "./ConfirmationModal";
@@ -24,6 +26,7 @@ const ProfileScreen: FC = () => {
     firstName: "John",
     lastName: "Smith",
   });
+  const [isLoadingSubmit, setLoadingSubmit] = useState(false);
 
   const openPasswordChangeModal = () => {
     setPasswordChangeModalOpen(true);
@@ -48,7 +51,15 @@ const ProfileScreen: FC = () => {
     });
   };
 
-  const handleFormSubmit = () => {};
+  /* TODO: Implement BE call on form submit */
+  const handleFormSubmit = () => {
+    setLoadingSubmit(true);
+
+    setTimeout(() => {
+      setLoadingSubmit(false);
+      toast.success("Profile successfully updated");
+    }, 2000);
+  };
 
   return (
     <>
@@ -96,8 +107,18 @@ const ProfileScreen: FC = () => {
         </Box>
       </Box>
 
-      <Button variant="contained" onClick={handleFormSubmit}>
-        Save
+      <Button
+        type="submit"
+        variant="contained"
+        disabled={isLoadingSubmit}
+        sx={{ flex: 1 }}
+        onClick={handleFormSubmit}
+      >
+        {isLoadingSubmit ? (
+          <CircularProgress sx={{ color: "white" }} size={24} />
+        ) : (
+          "Save"
+        )}
       </Button>
 
       <Dialog

--- a/packages/rockets-next-web/src/app/(main)/profile/types.ts
+++ b/packages/rockets-next-web/src/app/(main)/profile/types.ts
@@ -1,9 +1,3 @@
-export interface UserData {
-  id: string;
-  username: string;
-  email: string;
-}
-
 export interface PasswordChangeFormData {
   oldPassword: string;
   newPassword: string;

--- a/packages/rockets-next-web/src/app/(main)/profile/types.ts
+++ b/packages/rockets-next-web/src/app/(main)/profile/types.ts
@@ -1,3 +1,9 @@
+export interface ProfileFormData {
+  email: string;
+  firstName: string;
+  lastName: string;
+}
+
 export interface PasswordChangeFormData {
   oldPassword: string;
   newPassword: string;

--- a/packages/rockets-next-web/src/app/(main)/users/UserForm.tsx
+++ b/packages/rockets-next-web/src/app/(main)/users/UserForm.tsx
@@ -11,10 +11,12 @@ import validator from "@rjsf/validator-ajv6";
 import { toast } from "react-toastify";
 
 import { schema, widgets, getUiSchemaByViewMode } from "./formConfig";
-import type { FormData, ActionType } from "./types";
+import type { ActionType } from "./types";
+
+import type { User } from "@/types/User";
 
 interface UserFormProps {
-  selectedRow?: FormData | null;
+  selectedRow?: User | null;
   viewMode: ActionType;
   onSubmitSuccess: () => void;
   onCancel: () => void;
@@ -29,7 +31,7 @@ const UserForm: FC<UserFormProps> = ({
   const { post, patch } = useDataProvider();
 
   const { execute: createUser, isPending: isLoadingUserCreation } = useQuery(
-    (data: FormData) =>
+    (data: User) =>
       post({
         uri: `/user`,
         body: data,
@@ -45,7 +47,7 @@ const UserForm: FC<UserFormProps> = ({
   );
 
   const { execute: editUser, isPending: isLoadingUserEdit } = useQuery(
-    (data: FormData) =>
+    (data: User) =>
       patch({
         uri: `/user/${data.id}`,
         body: data,
@@ -60,7 +62,7 @@ const UserForm: FC<UserFormProps> = ({
     }
   );
 
-  const handleFormSubmit = async (values: IChangeEvent<FormData>) => {
+  const handleFormSubmit = async (values: IChangeEvent<User>) => {
     const fields = values.formData;
 
     if (viewMode === "creation") {

--- a/packages/rockets-next-web/src/app/(main)/users/UsersTable.tsx
+++ b/packages/rockets-next-web/src/app/(main)/users/UsersTable.tsx
@@ -11,17 +11,19 @@ import DeleteIcon from "@mui/icons-material/Delete";
 import Table from "@/components/Table/Table";
 
 import { headers } from "./tableConfig";
-import type { FormData, ActionType } from "./types";
+import type { ActionType } from "./types";
+
+import type { User } from "@/types/User";
 
 interface UsersTableProps {
   isLoading?: boolean;
   isEmptyStateVisible?: boolean;
-  data: FormData[];
+  data: User[];
   onActionClick: ({
     rowData,
     action,
   }: {
-    rowData: FormData;
+    rowData: User;
     action: ActionType;
   }) => void;
 }
@@ -33,7 +35,7 @@ const UsersTable: FC<UsersTableProps> = ({
   onActionClick,
 }) => {
   const handleActionButtonClick = useCallback(
-    (rowData: FormData, action: ActionType) =>
+    (rowData: User, action: ActionType) =>
       onActionClick({ rowData: rowData, action }),
     [onActionClick]
   );
@@ -77,8 +79,9 @@ const UsersTable: FC<UsersTableProps> = ({
     <Table
       rows={customRows}
       headers={headers}
+      data={data}
       isEmptyStateVisible={isEmptyStateVisible}
-      isLoading={isLoading}
+      isPending={Boolean(isLoading)}
     />
   );
 };

--- a/packages/rockets-next-web/src/app/(main)/users/UsersTable.tsx
+++ b/packages/rockets-next-web/src/app/(main)/users/UsersTable.tsx
@@ -14,8 +14,9 @@ import { headers } from "./tableConfig";
 import type { ActionType } from "./types";
 
 import type { User } from "@/types/User";
+import type { TableRootProps } from "@/types/Table";
 
-interface UsersTableProps {
+type UsersTableProps = {
   isLoading?: boolean;
   isEmptyStateVisible?: boolean;
   data: User[];
@@ -26,13 +27,14 @@ interface UsersTableProps {
     rowData: User;
     action: ActionType;
   }) => void;
-}
+} & Omit<TableRootProps, "rows" | "headers">;
 
 const UsersTable: FC<UsersTableProps> = ({
   isLoading,
   isEmptyStateVisible,
   data,
   onActionClick,
+  ...tableRootProps
 }) => {
   const handleActionButtonClick = useCallback(
     (rowData: User, action: ActionType) =>
@@ -82,6 +84,7 @@ const UsersTable: FC<UsersTableProps> = ({
       data={data}
       isEmptyStateVisible={isEmptyStateVisible}
       isPending={Boolean(isLoading)}
+      {...tableRootProps}
     />
   );
 };

--- a/packages/rockets-next-web/src/app/(main)/users/page.tsx
+++ b/packages/rockets-next-web/src/app/(main)/users/page.tsx
@@ -12,7 +12,9 @@ import { useDebounce } from "use-debounce";
 
 import UsersTable from "./UsersTable";
 import UserForm from "./UserForm";
-import type { FormData, ActionType } from "./types";
+import type { ActionType } from "./types";
+
+import type { User } from "@/types/User";
 
 interface DrawerState {
   isOpen: boolean;
@@ -25,7 +27,7 @@ const UsersScreen: FC = () => {
     isOpen: false,
     viewMode: null,
   });
-  const [selectedRow, setSelectedRow] = useState<FormData | null>();
+  const [selectedRow, setSelectedRow] = useState<User | null>();
 
   const [debouncedSearch] = useDebounce(searchTerm, 1000);
 
@@ -49,7 +51,7 @@ const UsersScreen: FC = () => {
   );
 
   const { execute: deleteUser } = useQuery(
-    (id: FormData["id"]) =>
+    (id: User["id"]) =>
       del({
         uri: `/user/${id}`,
       }),
@@ -64,7 +66,7 @@ const UsersScreen: FC = () => {
   );
 
   const deleteRow = useCallback(
-    async (rowId: FormData["id"]) => {
+    async (rowId: User["id"]) => {
       await deleteUser(rowId);
       resetDrawerState();
     },
@@ -75,7 +77,7 @@ const UsersScreen: FC = () => {
     rowData,
     action,
   }: {
-    rowData: FormData;
+    rowData: User;
     action: ActionType;
   }) => {
     if (action === "delete") {

--- a/packages/rockets-next-web/src/app/(main)/users/types.ts
+++ b/packages/rockets-next-web/src/app/(main)/users/types.ts
@@ -1,7 +1,1 @@
-export interface FormData {
-  id?: string;
-  email: string;
-  username: string;
-}
-
 export type ActionType = "creation" | "edit" | "details" | "delete" | null;

--- a/packages/rockets-next-web/src/components/AppBarContainer/AppBarContainer.tsx
+++ b/packages/rockets-next-web/src/components/AppBarContainer/AppBarContainer.tsx
@@ -9,13 +9,9 @@ import MenuItem from "@mui/material/MenuItem";
 import PersonOutlinedIcon from "@mui/icons-material/PersonOutlined";
 import GroupsOutlinedIcon from "@mui/icons-material/GroupsOutlined";
 
-type HandleCloseMenu = () => void;
+import type { User } from "@/types/User";
 
-interface UserData {
-  id: string;
-  username: string;
-  email: string;
-}
+type HandleCloseMenu = () => void;
 
 export default function AppBarContainer({ children }: { children: ReactNode }) {
   const pathname = usePathname();
@@ -55,7 +51,7 @@ export default function AppBarContainer({ children }: { children: ReactNode }) {
       />
       <AppBar.Main>
         <AppBar.Nav
-          text={(user as UserData)?.username || ""}
+          text={(user as User)?.username || ""}
           avatar="https://source.unsplash.com/random"
           headerMenuOptions={(handleClose) => (
             <MenuItem onClick={() => onLogoutClick(handleClose)}>

--- a/packages/rockets-next-web/src/components/ForgotPasswordScreen/ForgotPasswordScreen.tsx
+++ b/packages/rockets-next-web/src/components/ForgotPasswordScreen/ForgotPasswordScreen.tsx
@@ -15,17 +15,19 @@ import { toast } from "react-toastify";
 
 import { schema, widgets } from "./formConfig";
 
-interface FormData {
+interface ForgotPasswordFormData {
   email: string;
 }
 
 const ForgotPasswordScreen: FC = () => {
-  const [formData, setFormData] = useState<FormData>({ email: "" });
+  const [formData, setFormData] = useState<ForgotPasswordFormData>({
+    email: "",
+  });
 
   const { post } = useDataProvider();
 
   const { execute: sendRecoveryPasswordLink, isPending } = useQuery(
-    (body: FormData) =>
+    (body: ForgotPasswordFormData) =>
       post({
         uri: "/auth/recovery/password",
         body: { email: body.email },
@@ -45,7 +47,7 @@ const ForgotPasswordScreen: FC = () => {
     }
   );
 
-  const handleSubmit = async (values: IChangeEvent<FormData>) => {
+  const handleSubmit = async (values: IChangeEvent<ForgotPasswordFormData>) => {
     const { email } = values.formData || {};
     await sendRecoveryPasswordLink({ email });
   };

--- a/packages/rockets-next-web/src/components/ResetPasswordScreen/ResetPasswordScreen.tsx
+++ b/packages/rockets-next-web/src/components/ResetPasswordScreen/ResetPasswordScreen.tsx
@@ -14,11 +14,17 @@ import { IChangeEvent } from "@rjsf/core";
 import validator from "@rjsf/validator-ajv6";
 import { toast } from "react-toastify";
 
-import { schema, uiSchema, FormData, validationRules } from "./formConfig";
+import {
+  schema,
+  uiSchema,
+  ResetPasswordFormData,
+  validationRules,
+} from "./formConfig";
+
 import { validateForm } from "@/utils/formValidation/formValidation";
 
 const ResetPasswordScreen: FC = () => {
-  const [formData, setFormData] = useState<FormData>({
+  const [formData, setFormData] = useState<ResetPasswordFormData>({
     newPassword: "",
     confirmNewPassword: "",
   });
@@ -29,7 +35,7 @@ const ResetPasswordScreen: FC = () => {
   const token = searchParams.get("token");
 
   const { execute: resetPassword, isPending } = useQuery(
-    (body: FormData) =>
+    (body: ResetPasswordFormData) =>
       patch({
         uri: "/auth/recovery/password",
         body: { passcode: token, newPassword: body.newPassword },
@@ -47,7 +53,7 @@ const ResetPasswordScreen: FC = () => {
     }
   );
 
-  const handleSubmit = async (values: IChangeEvent<FormData>) => {
+  const handleSubmit = async (values: IChangeEvent<ResetPasswordFormData>) => {
     await resetPassword(values.formData || {});
   };
 

--- a/packages/rockets-next-web/src/components/ResetPasswordScreen/formConfig.ts
+++ b/packages/rockets-next-web/src/components/ResetPasswordScreen/formConfig.ts
@@ -4,7 +4,7 @@ import { CustomPasswordFieldWidget } from "@concepta/react-material-ui/dist/styl
 
 import { ValidationRule } from "@/utils/formValidation/formValidation";
 
-export interface FormData {
+export interface ResetPasswordFormData {
   newPassword: string;
   confirmNewPassword: string;
 }
@@ -42,7 +42,7 @@ export const uiSchema: UiSchema = {
   },
 };
 
-export const validationRules: ValidationRule<FormData>[] = [
+export const validationRules: ValidationRule<ResetPasswordFormData>[] = [
   {
     field: "confirmNewPassword",
     test: (value, formData) => value !== formData.newPassword,

--- a/packages/rockets-next-web/src/components/Table/Table.tsx
+++ b/packages/rockets-next-web/src/components/Table/Table.tsx
@@ -1,34 +1,54 @@
 "use client";
 
-import type {
-  HeaderProps,
-  RowProps,
-} from "@concepta/react-material-ui/dist/components/Table/types";
 import type { FC } from "react";
 import {
   Table as RocketsTable,
   createTableStyles,
-} from "@concepta/react-material-ui";
+} from "@concepta/react-material-ui/";
 import {
+  HeaderProps,
+  RowProps,
+  TableQueryStateProps,
+} from "@concepta/react-material-ui/dist/components/Table/types";
+import {
+  TableBody,
+  TableCell,
   TableContainer,
   TableHead,
-  TableBody,
   TableRow,
-  TableCell,
   useTheme,
 } from "@mui/material";
 
-interface TableProps {
-  rows: RowProps[];
-  headers: HeaderProps[];
-  isLoading?: boolean;
+type TableRootProps =
+  | {
+      rows: RowProps[];
+      headers: HeaderProps[];
+      total?: number;
+      pageCount?: never;
+      tableQueryState?: never;
+      updateTableQueryState?: never;
+    }
+  | {
+      rows: RowProps[];
+      headers: HeaderProps[];
+      total: number;
+      pageCount: number;
+      tableQueryState: TableQueryStateProps;
+      updateTableQueryState: React.Dispatch<
+        React.SetStateAction<TableQueryStateProps>
+      >;
+    };
+
+type TableProps = {
+  isPending: boolean;
+  data: unknown[];
   isEmptyStateVisible?: boolean;
-}
+} & TableRootProps;
 
 const Table: FC<TableProps> = ({
   rows,
   headers,
-  isLoading,
+  isPending,
   isEmptyStateVisible,
 }) => {
   const theme = useTheme();
@@ -84,7 +104,7 @@ const Table: FC<TableProps> = ({
                 </TableCell>
               </TableRow>
             )}
-            <RocketsTable.BodyRows isLoading={isLoading} />
+            <RocketsTable.BodyRows isLoading={isPending} />
           </TableBody>
         </RocketsTable.Table>
       </TableContainer>

--- a/packages/rockets-next-web/src/components/Table/Table.tsx
+++ b/packages/rockets-next-web/src/components/Table/Table.tsx
@@ -6,11 +6,6 @@ import {
   createTableStyles,
 } from "@concepta/react-material-ui/";
 import {
-  HeaderProps,
-  RowProps,
-  TableQueryStateProps,
-} from "@concepta/react-material-ui/dist/components/Table/types";
-import {
   TableBody,
   TableCell,
   TableContainer,
@@ -19,25 +14,7 @@ import {
   useTheme,
 } from "@mui/material";
 
-type TableRootProps =
-  | {
-      rows: RowProps[];
-      headers: HeaderProps[];
-      total?: number;
-      pageCount?: never;
-      tableQueryState?: never;
-      updateTableQueryState?: never;
-    }
-  | {
-      rows: RowProps[];
-      headers: HeaderProps[];
-      total: number;
-      pageCount: number;
-      tableQueryState: TableQueryStateProps;
-      updateTableQueryState: React.Dispatch<
-        React.SetStateAction<TableQueryStateProps>
-      >;
-    };
+import { TableRootProps } from "@/types/Table";
 
 type TableProps = {
   isPending: boolean;
@@ -50,6 +27,7 @@ const Table: FC<TableProps> = ({
   headers,
   isPending,
   isEmptyStateVisible,
+  ...tableRootProps
 }) => {
   const theme = useTheme();
 
@@ -79,7 +57,12 @@ const Table: FC<TableProps> = ({
   });
 
   return (
-    <RocketsTable.Root rows={rows} headers={headers} sx={tableTheme.root}>
+    <RocketsTable.Root
+      rows={rows}
+      headers={headers}
+      sx={tableTheme.root}
+      {...tableRootProps}
+    >
       <TableContainer sx={tableTheme.tableContainer}>
         <RocketsTable.Table
           stickyHeader

--- a/packages/rockets-next-web/src/types/Table.ts
+++ b/packages/rockets-next-web/src/types/Table.ts
@@ -1,0 +1,25 @@
+import {
+  HeaderProps,
+  RowProps,
+  TableQueryStateProps,
+} from "@concepta/react-material-ui/dist/components/Table/types";
+
+export type TableRootProps =
+  | {
+      rows: RowProps[];
+      headers: HeaderProps[];
+      total?: number;
+      pageCount?: never;
+      tableQueryState?: never;
+      updateTableQueryState?: never;
+    }
+  | {
+      rows: RowProps[];
+      headers: HeaderProps[];
+      total: number;
+      pageCount: number;
+      tableQueryState: TableQueryStateProps;
+      updateTableQueryState: React.Dispatch<
+        React.SetStateAction<TableQueryStateProps>
+      >;
+    };

--- a/packages/rockets-next-web/src/types/User.ts
+++ b/packages/rockets-next-web/src/types/User.ts
@@ -1,0 +1,10 @@
+export interface User {
+  id: string;
+  dateCreated: string;
+  dateUpdated: string;
+  dateDeleted: string | null;
+  version: number;
+  email: number;
+  username: string;
+  active: boolean;
+}

--- a/packages/rockets-next-web/src/types/User.ts
+++ b/packages/rockets-next-web/src/types/User.ts
@@ -4,7 +4,7 @@ export interface User {
   dateUpdated: string;
   dateDeleted: string | null;
   version: number;
-  email: number;
+  email: string;
   username: string;
   active: boolean;
 }


### PR DESCRIPTION
## Creation of `types` directory

Some components had global types implemented inside their scope and the same implementation was repeated in other components, so a folder for common (or specific) types was created.

## Refactor on `Table` implementation

Previously, Table state and requests were managed using props and the `useQuery` hook. Now, the `useTable` hook is used for this purpose, returning all table query and state data.